### PR TITLE
fix: subpackages dts in node10

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,26 @@
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
+  "typesVersions": {
+    "*": {
+      "core": [
+        "./dist/core.d.mts"
+      ],
+      "wasm": [
+        "./dist/wasm.d.mts"
+      ],
+      "languages": [
+        "./dist/languages.d.mts"
+      ],
+      "themes": [
+        "./dist/themes.d.mts"
+      ],
+      "*": [
+        "./dist/*",
+        "./*"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Missing types in node10:

![imagen](https://github.com/antfu/shikiji/assets/6311119/0c4d7a12-44a3-487d-8076-d18903d7219c)

Using `typesVersions`:

![imagen](https://github.com/antfu/shikiji/assets/6311119/6403474e-870c-40c1-a454-f221278f90ec)
