### PR TITLE
fix: langs subpackage dts in node10

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,23 +19,23 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",
-      "import": "./dist/index.mjs"
+      "default": "./dist/index.mjs"
     },
     "./core": {
       "types": "./dist/core.d.mts",
-      "import": "./dist/core.mjs"
+      "default": "./dist/core.mjs"
     },
     "./wasm": {
       "types": "./dist/wasm.d.mts",
-      "import": "./dist/wasm.mjs"
+      "default": "./dist/wasm.mjs"
     },
     "./langs": {
       "types": "./dist/langs.d.mts",
-      "import": "./dist/langs.mjs"
+      "default": "./dist/langs.mjs"
     },
     "./themes": {
       "types": "./dist/themes.d.mts",
-      "import": "./dist/themes.mjs"
+      "default": "./dist/themes.mjs"
     },
     "./dist/*": "./dist/*",
     "./*": "./dist/*"
@@ -51,8 +51,8 @@
       "wasm": [
         "./dist/wasm.d.mts"
       ],
-      "languages": [
-        "./dist/languages.d.mts"
+      "langs": [
+        "./dist/langs.d.mts"
       ],
       "themes": [
         "./dist/themes.d.mts"


### PR DESCRIPTION
This PR fixes:
- `languages` subpackage has been renamed to `langs`, but the `typesVersions` entry still with old name.
- use `default` instead `import` in packages exports

Current version:

![imagen](https://github.com/antfu/shikiji/assets/6311119/10cb2a09-f0ab-4a12-aef6-bf0ac8665344)

With this PR:

![imagen](https://github.com/antfu/shikiji/assets/6311119/8477bf41-7276-44e2-85d4-94d5a8e49b13)

