### PR TITLE
feat: add `codeToHtmlDualThemes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An ESM-focused rewrite of [shiki](https://github.com/shikijs/shiki), a beautiful
 - Portable. Does not rely on Node.js APIs or the filesystem, works in any modern JavaScript runtime.
 - Drop CJS and IIFE build, focus on ESM (or you can use bundlers).
 - Bundles languages/themes composedly.
+- Light/Dark dual themes support.
 - Zero-dependencies.
 - Simplified APIs.
 - Please don't hate me Pine 😜 ([What's Next?](#whats-next))
@@ -51,6 +52,12 @@ import { codeToHtml } from 'shikiji'
 const code1 = await codeToHtml('const a = 1', { lang: 'javascript', theme: 'nord' })
 const code2 = await codeToHtml('<div class="foo">bar</div>', { lang: 'html', theme: 'min-dark' })
 ```
+
+Currently supports:
+
+- `codeToThemedTokens`
+- `codeToHtml`
+- `codeToHtmlDualThemes`
 
 Internally they maintains a singleton highlighter instance and load the theme/language on demand. Different from `shiki.codeToHtml`, the `codeToHtml` shorthand function returns a Promise and `lang` and `theme` options are required.
 
@@ -153,6 +160,82 @@ export default {
 
     return new Response(highlighter.codeToHtml('console.log(\'shiki\');', { lang: 'js' }))
   },
+}
+```
+
+## Additional Features
+
+### Light/Dark Dual Themes
+
+`shikiji` added an experimental light/dark dual themes support. Different from [markdown-it-shiki](https://github.com/antfu/markdown-it-shiki#dark-mode)'s approach which renders the code twice, `shikiji`'s dual themes approach uses CSS variables to store the colors on each token. It's more performant with a smaller bundle size.
+
+Use `codeToHtmlDualThemes` to render the code with dual themes:
+
+```js
+import { getHighlighter } from 'shikiji'
+
+const shiki = await getHighlighter({
+  themes: ['nord', 'min-light'],
+  langs: ['javascript'],
+})
+
+const code = shiki.codeToHtmlDualThemes('console.log("hello")', {
+  lang: 'javascript',
+  theme: {
+    light: 'min-light',
+    dark: 'nord',
+  }
+})
+```
+
+The following HTML will be generated:
+
+```html
+<pre
+  class="shiki shiki-dual-themes min-light--nord"
+  style="background-color: #ffffff;--shiki-dark-bg:#2e3440ff;color: #ffffff;--shiki-dark-bg:#2e3440ff"
+  tabindex="0"
+>
+  <code>
+    <span class="line">
+      <span style="color:#1976D2;--shiki-dark:#D8DEE9">console</span>
+      <span style="color:#6F42C1;--shiki-dark:#ECEFF4">.</span>
+      <span style="color:#6F42C1;--shiki-dark:#88C0D0">log</span>
+      <span style="color:#24292EFF;--shiki-dark:#D8DEE9FF">(</span>
+      <span style="color:#22863A;--shiki-dark:#ECEFF4">&quot;</span>
+      <span style="color:#22863A;--shiki-dark:#A3BE8C">hello</span>
+      <span style="color:#22863A;--shiki-dark:#ECEFF4">&quot;</span>
+      <span style="color:#24292EFF;--shiki-dark:#D8DEE9FF">)</span>
+    </span>
+  </code>
+</pre>
+```
+
+To make it reactive to your site's theme, you need to add a short CSS snippet:
+
+###### Query-based Dark Mode
+
+```css
+@media (prefers-color-scheme: dark) {
+  .shiki {
+    background-color: var(--shiki-dark-bg) !important;
+    color: var(--shiki-dark) !important;
+  }
+  .shiki span {
+    color: var(--shiki-dark) !important;
+  }
+}
+```
+
+###### Class-based Dark Mode
+
+```css
+html.dark .shiki {
+  background-color: var(--shiki-dark-bg) !important;
+  color: var(--shiki-dark) !important;
+}
+html.dark .shiki span {
+  color: var(--shiki-dark) !important;
 }
 ```
 

--- a/src/bundled/singleton.ts
+++ b/src/bundled/singleton.ts
@@ -1,4 +1,4 @@
-import type { BuiltinLanguages, BuiltinThemes, CodeToHtmlOptions, CodeToThemedTokensOptions, PlainTextLanguage, RequireKeys } from '../types'
+import type { BuiltinLanguages, BuiltinThemes, CodeToHtmlDualThemesOptions, CodeToHtmlOptions, CodeToThemedTokensOptions, PlainTextLanguage, RequireKeys } from '../types'
 import { getHighlighter } from './highlighter'
 import type { Highlighter } from './highlighter'
 
@@ -42,4 +42,16 @@ export async function codeToHtml(code: string, options: RequireKeys<CodeToHtmlOp
 export async function codeToThemedTokens(code: string, options: RequireKeys<CodeToThemedTokensOptions<BuiltinLanguages, BuiltinThemes>, 'theme' | 'lang'>) {
   const shiki = await getShikiWithThemeLang(options)
   return shiki.codeToThemedTokens(code, options)
+}
+
+/**
+ * Shorthand for `codeToHtmlDualThemes` with auto-loaded theme and language.
+ * A singleton highlighter it maintained internally.
+ *
+ * Differences from `shiki.codeToHtmlDualThemes()`, this function is async.
+ */
+export async function codeToHtmlDualThemes(code: string, options: RequireKeys<CodeToHtmlDualThemesOptions<BuiltinLanguages, BuiltinThemes>, 'theme' | 'lang'>) {
+  const shiki = await getShikiWithThemeLang({ lang: options.lang, theme: options.theme.light })
+  await shiki.loadTheme(options.theme.dark)
+  return shiki.codeToHtmlDualThemes(code, options)
 }

--- a/src/core/renderer-html-dual-themes.ts
+++ b/src/core/renderer-html-dual-themes.ts
@@ -1,0 +1,93 @@
+import type { HtmlRendererOptions, ThemedToken } from '../types'
+import { renderToHtml } from './renderer-html'
+
+export function _syncTwoThemedTokens(tokens1: ThemedToken[][], tokens2: ThemedToken[][]) {
+  const out1: ThemedToken[][] = []
+  const out2: ThemedToken[][] = []
+
+  for (let i = 0; i < tokens1.length; i++) {
+    const line1 = tokens1[i]
+    const line2 = tokens2[i]
+
+    const line1out: ThemedToken[] = []
+    const line2out: ThemedToken[] = []
+    out1.push(line1out)
+    out2.push(line2out)
+
+    let i1 = 0
+    let i2 = 0
+
+    let token1 = line1[i1]
+    let token2 = line2[i2]
+
+    while (token1 && token2) {
+      if (token1.content.length > token2.content.length) {
+        line1out.push(
+          {
+            ...token1,
+            content: token1.content.slice(0, token2.content.length),
+          },
+        )
+        token1 = {
+          ...token1,
+          content: token1.content.slice(token2.content.length),
+        }
+        line2out.push(token2)
+        i2 += 1
+        token2 = line2[i2]
+      }
+      else if (token1.content.length < token2.content.length) {
+        line2out.push(
+          {
+            ...token2,
+            content: token2.content.slice(0, token1.content.length),
+          },
+        )
+        token2 = {
+          ...token2,
+          content: token2.content.slice(token1.content.length),
+        }
+        line1out.push(token1)
+        i1 += 1
+        token1 = line1[i1]
+      }
+      else {
+        line1out.push(token1)
+        line2out.push(token2)
+        i1 += 1
+        i2 += 1
+        token1 = line1[i1]
+        token2 = line2[i2]
+      }
+    }
+  }
+
+  return [out1, out2]
+}
+
+export function renderToHtmlDualThemes(
+  tokens1: ThemedToken[][],
+  tokens2: ThemedToken[][],
+  cssName = '--shiki-dark',
+  options: HtmlRendererOptions = {},
+) {
+  const [synced1, synced2] = _syncTwoThemedTokens(tokens1, tokens2)
+
+  const merged: ThemedToken[][] = []
+  for (let i = 0; i < synced1.length; i++) {
+    const line1 = synced1[i]
+    const line2 = synced2[i]
+    const lineout: any[] = []
+    merged.push(lineout)
+    for (let j = 0; j < line1.length; j++) {
+      const token1 = line1[j]
+      const token2 = line2[j]
+      lineout.push({
+        ...token1,
+        color: `${token1.color || 'inherit'};${cssName}: ${token2.color || 'inherit'}`,
+      })
+    }
+  }
+
+  return renderToHtml(merged, options)
+}

--- a/src/core/renderer-html.ts
+++ b/src/core/renderer-html.ts
@@ -18,6 +18,7 @@ const defaultElements: ElementsOptions = {
 
 export function renderToHtml(lines: ThemedToken[][], options: HtmlRendererOptions = {}) {
   const bg = options.bg || '#fff'
+  const fg = options.bg || '#000'
   const optionsByLineNumber = groupBy(options.lineOptions ?? [], option => option.line)
   const userElements = options.elements || {}
 
@@ -38,7 +39,7 @@ export function renderToHtml(lines: ThemedToken[][], options: HtmlRendererOption
 
   return h(
     'pre',
-    { className: `shiki ${options.themeName || ''}`, style: `background-color: ${bg}` },
+    { className: `shiki ${options.themeName || ''}`, style: `background-color: ${bg}; color: ${fg}` },
     [
       options.langId ? `<div class="language-id">${options.langId}</div>` : '',
       h(

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,23 @@ export interface CodeToHtmlOptions<Languages = string, Themes = string> {
   lineOptions?: LineOption[]
 }
 
+export interface CodeToHtmlDualThemesOptions<Languages = string, Themes = string> {
+  lang?: Languages | PlainTextLanguage
+  theme: {
+    light: Themes
+    dark: Themes
+  }
+  /**
+   * @default 'light'
+   */
+  defaultColor?: 'light' | 'dark'
+  /**
+   * @default '--shiki-dark'
+   */
+  cssVariableName?: string
+  lineOptions?: LineOption[]
+}
+
 export interface CodeToThemedTokensOptions<Languages = string, Themes = string> {
   lang?: Languages | PlainTextLanguage
   theme?: Themes

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -18,7 +18,7 @@ describe('should', () => {
     })
 
     expect(shiki.codeToHtml('console.log("Hi")', { lang: 'javascript' }))
-      .toMatchInlineSnapshot('"<pre class=\\"shiki nord\\" style=\\"background-color: #2e3440ff\\" tabindex=\\"0\\"><code><span class=\\"line\\"><span style=\\"color: #D8DEE9\\">console</span><span style=\\"color: #ECEFF4\\">.</span><span style=\\"color: #88C0D0\\">log</span><span style=\\"color: #D8DEE9FF\\">(</span><span style=\\"color: #ECEFF4\\">&quot;</span><span style=\\"color: #A3BE8C\\">Hi</span><span style=\\"color: #ECEFF4\\">&quot;</span><span style=\\"color: #D8DEE9FF\\">)</span></span></code></pre>"')
+      .toMatchInlineSnapshot('"<pre class=\\"shiki nord\\" style=\\"background-color: #2e3440ff; color: #2e3440ff\\" tabindex=\\"0\\"><code><span class=\\"line\\"><span style=\\"color: #D8DEE9\\">console</span><span style=\\"color: #ECEFF4\\">.</span><span style=\\"color: #88C0D0\\">log</span><span style=\\"color: #D8DEE9FF\\">(</span><span style=\\"color: #ECEFF4\\">&quot;</span><span style=\\"color: #A3BE8C\\">Hi</span><span style=\\"color: #ECEFF4\\">&quot;</span><span style=\\"color: #D8DEE9FF\\">)</span></span></code></pre>"')
   })
 
   it('dynamic load theme and lang', async () => {
@@ -55,7 +55,7 @@ describe('should', () => {
       `)
 
     expect(shiki.codeToHtml('print 1', { lang: 'python', theme: 'vitesse-light' }))
-      .toMatchInlineSnapshot('"<pre class=\\"shiki vitesse-light\\" style=\\"background-color: #ffffff\\" tabindex=\\"0\\"><code><span class=\\"line\\"><span style=\\"color: #998418\\">print</span><span style=\\"color: #393A34\\"> </span><span style=\\"color: #2F798A\\">1</span></span></code></pre>"')
+      .toMatchInlineSnapshot('"<pre class=\\"shiki vitesse-light\\" style=\\"background-color: #ffffff; color: #ffffff\\" tabindex=\\"0\\"><code><span class=\\"line\\"><span style=\\"color: #998418\\">print</span><span style=\\"color: #393A34\\"> </span><span style=\\"color: #2F798A\\">1</span></span></code></pre>"')
   })
 
   it('requires nested lang', async () => {

--- a/test/dual-themes.test.ts
+++ b/test/dual-themes.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import type { ThemedToken } from '../src'
+import { codeToHtmlDualThemes, codeToThemedTokens } from '../src'
+import { _syncTwoThemedTokens } from '../src/core/renderer-html-dual-themes'
+
+describe('should', () => {
+  it('syncTwoThemedTokens', async () => {
+    function stringifyTokens(tokens: ThemedToken[][]) {
+      return tokens.map(line => line.map(token => token.content).join('_')).join('\n')
+    }
+
+    const lines1 = await codeToThemedTokens('console.log("hello")', { lang: 'js', theme: 'vitesse-dark', includeExplanation: true })
+    const lines2 = await codeToThemedTokens('console.log("hello")', { lang: 'js', theme: 'min-light', includeExplanation: true })
+
+    expect(stringifyTokens(lines1))
+      .toMatchInlineSnapshot('"console_._log_(_\\"_hello_\\"_)"')
+    expect(stringifyTokens(lines2))
+      .toMatchInlineSnapshot('"console_.log_(_\\"hello\\"_)"')
+
+    const [out1, out2] = _syncTwoThemedTokens(lines1, lines2)
+
+    expect(stringifyTokens(out1))
+      .toBe(stringifyTokens(out2))
+  })
+
+  it('codeToHtmlDualThemes', async () => {
+    const code = await codeToHtmlDualThemes('console.log("hello")', {
+      lang: 'js',
+      theme: {
+        dark: 'nord',
+        light: 'min-light',
+      },
+    })
+
+    const snippet = `
+<style>
+.dark .shiki {
+  background-color: var(--shiki-dark-bg) !important;
+  color: var(--shiki-dark) !important;
+}
+.dark .shiki span {
+  color: var(--shiki-dark) !important;
+}
+</style>
+<button onclick="document.body.classList.toggle('dark')">Toggle theme</button>
+`
+
+    expect(snippet + code)
+      .toMatchFileSnapshot('./out/dual-themes.html')
+  })
+})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,7 +9,7 @@ describe('should', () => {
     })
 
     expect(shiki.codeToHtml('console.log', { lang: 'js' }))
-      .toMatchInlineSnapshot('"<pre class=\\"shiki vitesse-light\\" style=\\"background-color: #ffffff\\" tabindex=\\"0\\"><code><span class=\\"line\\"><span style=\\"color: #B07D48\\">console</span><span style=\\"color: #999999\\">.</span><span style=\\"color: #B07D48\\">log</span></span></code></pre>"')
+      .toMatchInlineSnapshot('"<pre class=\\"shiki vitesse-light\\" style=\\"background-color: #ffffff; color: #ffffff\\" tabindex=\\"0\\"><code><span class=\\"line\\"><span style=\\"color: #B07D48\\">console</span><span style=\\"color: #999999\\">.</span><span style=\\"color: #B07D48\\">log</span></span></code></pre>"')
   })
 
   it('dynamic load theme and lang', async () => {
@@ -41,7 +41,7 @@ describe('should', () => {
       `)
 
     expect(shiki.codeToHtml('print 1', { lang: 'python', theme: 'min-dark' }))
-      .toMatchInlineSnapshot('"<pre class=\\"shiki min-dark\\" style=\\"background-color: #1f1f1f\\" tabindex=\\"0\\"><code><span class=\\"line\\"><span style=\\"color: #B392F0\\">print </span><span style=\\"color: #F8F8F8\\">1</span></span></code></pre>"')
+      .toMatchInlineSnapshot('"<pre class=\\"shiki min-dark\\" style=\\"background-color: #1f1f1f; color: #1f1f1f\\" tabindex=\\"0\\"><code><span class=\\"line\\"><span style=\\"color: #B392F0\\">print </span><span style=\\"color: #F8F8F8\\">1</span></span></code></pre>"')
   })
 
   it('requires nested lang', async () => {

--- a/test/out/dual-themes.html
+++ b/test/out/dual-themes.html
@@ -1,0 +1,12 @@
+
+<style>
+.dark .shiki {
+  background-color: var(--shiki-dark-bg) !important;
+  color: var(--shiki-dark) !important;
+}
+.dark .shiki span {
+  color: var(--shiki-dark) !important;
+}
+</style>
+<button onclick="document.body.classList.toggle('dark')">Toggle theme</button>
+<pre class="shiki shiki-dual-themes min-light--nord" style="background-color: #ffffff;--shiki-dark-bg:#2e3440ff; color: #ffffff;--shiki-dark-bg:#2e3440ff" tabindex="0"><code><span class="line"><span style="color: #1976D2;--shiki-dark: #D8DEE9">console</span><span style="color: #6F42C1;--shiki-dark: #ECEFF4">.</span><span style="color: #6F42C1;--shiki-dark: #88C0D0">log</span><span style="color: #24292EFF;--shiki-dark: #D8DEE9FF">(</span><span style="color: #22863A;--shiki-dark: #ECEFF4">&quot;</span><span style="color: #22863A;--shiki-dark: #A3BE8C">hello</span><span style="color: #22863A;--shiki-dark: #ECEFF4">&quot;</span><span style="color: #24292EFF;--shiki-dark: #D8DEE9FF">)</span></span></code></pre>

--- a/test/singleton.test.ts
+++ b/test/singleton.test.ts
@@ -4,10 +4,10 @@ import { codeToHtml, codeToThemedTokens } from '../src'
 describe('should', () => {
   it('codeToHtml', async () => {
     expect(await codeToHtml('console.log("hello")', { lang: 'js', theme: 'vitesse-light' }))
-      .toMatchInlineSnapshot('"<pre class=\\"shiki vitesse-light\\" style=\\"background-color: #ffffff\\" tabindex=\\"0\\"><code><span class=\\"line\\"><span style=\\"color: #B07D48\\">console</span><span style=\\"color: #999999\\">.</span><span style=\\"color: #59873A\\">log</span><span style=\\"color: #999999\\">(</span><span style=\\"color: #B5695999\\">&quot;</span><span style=\\"color: #B56959\\">hello</span><span style=\\"color: #B5695999\\">&quot;</span><span style=\\"color: #999999\\">)</span></span></code></pre>"')
+      .toMatchInlineSnapshot('"<pre class=\\"shiki vitesse-light\\" style=\\"background-color: #ffffff; color: #ffffff\\" tabindex=\\"0\\"><code><span class=\\"line\\"><span style=\\"color: #B07D48\\">console</span><span style=\\"color: #999999\\">.</span><span style=\\"color: #59873A\\">log</span><span style=\\"color: #999999\\">(</span><span style=\\"color: #B5695999\\">&quot;</span><span style=\\"color: #B56959\\">hello</span><span style=\\"color: #B5695999\\">&quot;</span><span style=\\"color: #999999\\">)</span></span></code></pre>"')
 
     expect(await codeToHtml('<div class="foo">bar</div>', { lang: 'html', theme: 'min-dark' }))
-      .toMatchInlineSnapshot('"<pre class=\\"shiki min-dark\\" style=\\"background-color: #1f1f1f\\" tabindex=\\"0\\"><code><span class=\\"line\\"><span style=\\"color: #B392F0\\">&lt;</span><span style=\\"color: #FFAB70\\">div</span><span style=\\"color: #B392F0\\"> class</span><span style=\\"color: #F97583\\">=</span><span style=\\"color: #FFAB70\\">&quot;foo&quot;</span><span style=\\"color: #B392F0\\">&gt;bar&lt;/</span><span style=\\"color: #FFAB70\\">div</span><span style=\\"color: #B392F0\\">&gt;</span></span></code></pre>"')
+      .toMatchInlineSnapshot('"<pre class=\\"shiki min-dark\\" style=\\"background-color: #1f1f1f; color: #1f1f1f\\" tabindex=\\"0\\"><code><span class=\\"line\\"><span style=\\"color: #B392F0\\">&lt;</span><span style=\\"color: #FFAB70\\">div</span><span style=\\"color: #B392F0\\"> class</span><span style=\\"color: #F97583\\">=</span><span style=\\"color: #FFAB70\\">&quot;foo&quot;</span><span style=\\"color: #B392F0\\">&gt;bar&lt;/</span><span style=\\"color: #FFAB70\\">div</span><span style=\\"color: #B392F0\\">&gt;</span></span></code></pre>"')
   })
 
   it('codeToThemedTokens', async () => {


### PR DESCRIPTION

`shikiji` added an experimental light/dark dual themes support. Different from [markdown-it-shiki](https://github.com/antfu/markdown-it-shiki#dark-mode)'s approach which renders the code twice, `shikiji`'s dual themes approach uses CSS variables to store the colors on each token. It's more performant with a smaller bundle size.

Use `codeToHtmlDualThemes` to render the code with dual themes:

```js
import { getHighlighter } from 'shikiji'

const shiki = await getHighlighter({
  themes: ['nord', 'min-light'],
  langs: ['javascript'],
})

const code = shiki.codeToHtmlDualThemes('console.log("hello")', {
  lang: 'javascript',
  theme: {
    light: 'min-light',
    dark: 'nord',
  }
})
```

The following HTML will be generated:

```html
<pre
  class="shiki shiki-dual-themes min-light--nord"
  style="background-color: #ffffff;--shiki-dark-bg:#2e3440ff;color: #ffffff;--shiki-dark-bg:#2e3440ff"
  tabindex="0"
>
  <code>
    <span class="line">
      <span style="color:#1976D2;--shiki-dark:#D8DEE9">console</span>
      <span style="color:#6F42C1;--shiki-dark:#ECEFF4">.</span>
      <span style="color:#6F42C1;--shiki-dark:#88C0D0">log</span>
      <span style="color:#24292EFF;--shiki-dark:#D8DEE9FF">(</span>
      <span style="color:#22863A;--shiki-dark:#ECEFF4">&quot;</span>
      <span style="color:#22863A;--shiki-dark:#A3BE8C">hello</span>
      <span style="color:#22863A;--shiki-dark:#ECEFF4">&quot;</span>
      <span style="color:#24292EFF;--shiki-dark:#D8DEE9FF">)</span>
    </span>
  </code>
</pre>
```

To make it reactive to your site's theme, you need to add a short CSS snippet:

###### Query-based Dark Mode

```css
@media (prefers-color-scheme: dark) {
  .shiki {
    background-color: var(--shiki-dark-bg) !important;
    color: var(--shiki-dark) !important;
  }
  .shiki span {
    color: var(--shiki-dark) !important;
  }
}
```

###### Class-based Dark Mode

```css
html.dark .shiki {
  background-color: var(--shiki-dark-bg) !important;
  color: var(--shiki-dark) !important;
}
html.dark .shiki span {
  color: var(--shiki-dark) !important;
}
```