### PR TITLE
feat: support dual themes for themed tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Currently supports:
 - `codeToThemedTokens`
 - `codeToHtml`
 - `codeToHtmlDualThemes`
+- `codeToThemedTokensDualThemes`
 
 Internally they maintain a singleton highlighter instance and load the theme/language on demand. Different from `shiki.codeToHtml`, the `codeToHtml` shorthand function returns a Promise and `lang` and `theme` options are required.
 

--- a/packages/shikiji/src/bundled/shorthands.ts
+++ b/packages/shikiji/src/bundled/shorthands.ts
@@ -1,4 +1,4 @@
-import type { BuiltinLanguages, BuiltinThemes, CodeToHtmlDualThemesOptions, CodeToHtmlOptions, CodeToThemedTokensOptions, MaybeArray, PlainTextLanguage, RequireKeys } from '../types'
+import type { BuiltinLanguages, BuiltinThemes, CodeToHtmlDualThemesOptions, CodeToHtmlOptions, CodeToThemedTokensDualThemesOptions, CodeToThemedTokensOptions, MaybeArray, PlainTextLanguage, RequireKeys } from '../types'
 import { toArray } from '../core/utils'
 import { getHighlighter } from './highlighter'
 import type { Highlighter } from './highlighter'
@@ -57,4 +57,18 @@ export async function codeToHtmlDualThemes(code: string, options: RequireKeys<Co
     theme: Object.values(options.themes).filter(Boolean) as BuiltinThemes[],
   })
   return shiki.codeToHtmlDualThemes(code, options)
+}
+
+/**
+ * Shorthand for `codeToHtmlDualThemes` with auto-loaded theme and language.
+ * A singleton highlighter it maintained internally.
+ *
+ * Differences from `shiki.codeToHtmlDualThemes()`, this function is async.
+ */
+export async function codeToThemedTokensDualThemes(code: string, options: RequireKeys<CodeToThemedTokensDualThemesOptions<BuiltinLanguages, BuiltinThemes>, 'themes' | 'lang'>) {
+  const shiki = await getShikiWithThemeLang({
+    lang: options.lang,
+    theme: Object.values(options.themes).filter(Boolean) as BuiltinThemes[],
+  })
+  return shiki.codeToThemedTokensDualThemes(code, options)
 }

--- a/packages/shikiji/src/core/index.ts
+++ b/packages/shikiji/src/core/index.ts
@@ -160,7 +160,7 @@ export async function getHighlighterCore(options: HighlighterCoreOptions) {
         theme,
         includeExplanation,
       }),
-      getTheme(theme)._theme,
+      getTheme(theme),
     ] as [string, ThemedToken[][], ThemeRegisteration])
 
     return renderToThemedTokensDualThemes(

--- a/packages/shikiji/src/core/renderer-themed-tokens-dual-themes.ts
+++ b/packages/shikiji/src/core/renderer-themed-tokens-dual-themes.ts
@@ -1,0 +1,35 @@
+import type { ThemeRegisteration, ThemedToken } from '../types'
+import { _syncThemedTokens } from './renderer-html-dual-themes'
+
+export function renderToThemedTokensDualThemes(
+  themes: [string, ThemedToken[][], ThemeRegisteration][],
+  cssVariablePrefix = '--shiki-',
+  defaultColor = true,
+): { rootStyle: string; rootClass: string; tokens: ThemedToken[][] } {
+  const synced = _syncThemedTokens(...themes.map(t => t[1]))
+
+  const merged: ThemedToken[][] = []
+  for (let i = 0; i < synced[0].length; i++) {
+    const lines = synced.map(t => t[i])
+    const lineout: any[] = []
+    merged.push(lineout)
+    for (let j = 0; j < lines[0].length; j++) {
+      const tokens = lines.map(t => t[j])
+      const colors = tokens.map((t, idx) => `${idx === 0 && defaultColor ? '' : `${cssVariablePrefix + themes[idx][0]}:`}${t.color || 'inherit'}`).join(';')
+      lineout.push({
+        ...tokens[0],
+        color: colors,
+        htmlStyle: defaultColor ? undefined : colors,
+      })
+    }
+  }
+
+  const fg = themes.map((t, idx) => idx === 0 && defaultColor ? `color: ${t[2].fg}; ${cssVariablePrefix + t[0]}: ${t[2].fg}` : `${cssVariablePrefix + t[0]}: ${t[2].fg}`).join(';')
+  const bg = themes.map((t, idx) => idx === 0 && defaultColor ? `background-color: ${t[2].bg}; ${cssVariablePrefix + t[0]}-bg: ${t[2].bg}` : `${cssVariablePrefix + t[0]}-bg: ${t[2].bg}`).join(';')
+
+  return {
+    tokens: merged,
+    rootClass: `shiki shiki-dual-themes ${themes.map(t => t[2].name).join(' ')}`,
+    rootStyle: `${fg};${bg}`,
+  }
+}

--- a/packages/shikiji/src/types.ts
+++ b/packages/shikiji/src/types.ts
@@ -102,6 +102,66 @@ export interface CodeToHtmlDualThemesOptions<Languages = string, Themes = string
   lineOptions?: LineOption[]
 }
 
+export interface CodeToThemedTokensDualThemesOptions<Languages = string, Themes = string> {
+  lang?: Languages | PlainTextLanguage
+
+  /**
+   * A map of color names to themes.
+   *
+   * `light` and `dark` are required, and arbitrary color names can be added.
+   *
+   * @example
+   * ```ts
+   * themes: {
+   *   light: 'vitesse-light',
+   *   dark: 'vitesse-dark',
+   *   soft: 'nord',
+   *   // custom colors
+   * }
+   * ```
+   */
+  themes: {
+    light: Themes
+    dark: Themes
+  } & Partial<Record<string, Themes>>
+
+  /**
+   * The default theme applied to the code (via inline `color` style).
+   * The rest of the themes are applied via CSS variables, and toggled by CSS overrides.
+   *
+   * For example, if `defaultColor` is `light`, then `light` theme is applied to the code,
+   * and the `dark` theme and other custom themes are applied via CSS variables:
+   *
+   * ```html
+   * <span style="color:#{light};--shiki-dark:#{dark};--shiki-custom:#{custom};">code</span>
+   * ```
+   *
+   * When set to `false`, no default styles will be applied, and totally up to users to apply the styles:
+   *
+   * ```html
+   * <span style="--shiki-light:#{light};--shiki-dark:#{dark};--shiki-custom:#{custom};">code</span>
+   * ```
+   *
+   *
+   * @default 'light'
+   */
+  defaultColor?: StringLiteralUnion<'light' | 'dark'> | false
+
+  /**
+   * Prefix of CSS variables used to store the color of the other theme.
+   *
+   * @default '--shiki-'
+   */
+  cssVariablePrefix?: string
+
+  /**
+   * Include explanation of why a token is given a color.
+   *
+   * @default true
+   */
+  includeExplanation?: boolean
+}
+
 export interface CodeToThemedTokensOptions<Languages = string, Themes = string> {
   lang?: Languages | PlainTextLanguage
   theme?: Themes

--- a/packages/shikiji/src/types.ts
+++ b/packages/shikiji/src/types.ts
@@ -47,7 +47,7 @@ export interface CodeToHtmlOptions<Languages = string, Themes = string> {
   lineOptions?: LineOption[]
 }
 
-export interface CodeToHtmlDualThemesOptions<Languages = string, Themes = string> {
+export interface CodeToDualThemesOptions<Languages = string, Themes = string> {
   lang?: Languages | PlainTextLanguage
 
   /**
@@ -98,62 +98,13 @@ export interface CodeToHtmlDualThemesOptions<Languages = string, Themes = string
    * @default '--shiki-'
    */
   cssVariablePrefix?: string
+}
 
+export interface CodeToHtmlDualThemesOptions<Languages = string, Themes = string> extends CodeToDualThemesOptions<Languages, Themes> {
   lineOptions?: LineOption[]
 }
 
-export interface CodeToThemedTokensDualThemesOptions<Languages = string, Themes = string> {
-  lang?: Languages | PlainTextLanguage
-
-  /**
-   * A map of color names to themes.
-   *
-   * `light` and `dark` are required, and arbitrary color names can be added.
-   *
-   * @example
-   * ```ts
-   * themes: {
-   *   light: 'vitesse-light',
-   *   dark: 'vitesse-dark',
-   *   soft: 'nord',
-   *   // custom colors
-   * }
-   * ```
-   */
-  themes: {
-    light: Themes
-    dark: Themes
-  } & Partial<Record<string, Themes>>
-
-  /**
-   * The default theme applied to the code (via inline `color` style).
-   * The rest of the themes are applied via CSS variables, and toggled by CSS overrides.
-   *
-   * For example, if `defaultColor` is `light`, then `light` theme is applied to the code,
-   * and the `dark` theme and other custom themes are applied via CSS variables:
-   *
-   * ```html
-   * <span style="color:#{light};--shiki-dark:#{dark};--shiki-custom:#{custom};">code</span>
-   * ```
-   *
-   * When set to `false`, no default styles will be applied, and totally up to users to apply the styles:
-   *
-   * ```html
-   * <span style="--shiki-light:#{light};--shiki-dark:#{dark};--shiki-custom:#{custom};">code</span>
-   * ```
-   *
-   *
-   * @default 'light'
-   */
-  defaultColor?: StringLiteralUnion<'light' | 'dark'> | false
-
-  /**
-   * Prefix of CSS variables used to store the color of the other theme.
-   *
-   * @default '--shiki-'
-   */
-  cssVariablePrefix?: string
-
+export interface CodeToThemedTokensDualThemesOptions<Languages = string, Themes = string> extends CodeToDualThemesOptions<Languages, Themes> {
   /**
    * Include explanation of why a token is given a color.
    *

--- a/packages/shikiji/test/dual-themes.test.ts
+++ b/packages/shikiji/test/dual-themes.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import type { ThemedToken } from '../src'
-import { codeToHtmlDualThemes, codeToThemedTokens } from '../src'
+import { codeToHtmlDualThemes, codeToThemedTokens, codeToThemedTokensDualThemes } from '../src'
 import { _syncThemedTokens } from '../src/core/renderer-html-dual-themes'
+import { renderToHtml } from '../src/core/renderer-html'
 
 describe('syncThemedTokens', () => {
   function stringifyTokens(tokens: ThemedToken[][]) {
@@ -214,5 +215,156 @@ function toggleTheme() {
 
     expect(snippet + code)
       .toMatchFileSnapshot('./out/multiple-themes-no-default.html')
+  })
+})
+
+describe('codeToThemedTokensDualThemes', () => {
+  it('multiple themes', async () => {
+    const { rootClass, rootStyle, tokens } = await codeToThemedTokensDualThemes('console.log("hello")', {
+      lang: 'js',
+      themes: {
+        'light': 'vitesse-light',
+        'dark': 'vitesse-dark',
+        'nord': 'nord',
+        'min-dark': 'min-dark',
+        'min-light': 'min-light',
+      },
+      cssVariablePrefix: '--s-',
+    })
+
+    expect(rootClass).toEqual('shiki shiki-dual-themes vitesse-light vitesse-dark nord min-dark min-light')
+    expect(rootStyle).toEqual('color: #393a34; --s-light: #393a34;--s-dark: #dbd7caee;--s-nord: #d8dee9ff;--s-min-dark: #b392f0;--s-min-light: #24292eff;background-color: #ffffff; --s-light-bg: #ffffff;--s-dark-bg: #121212;--s-nord-bg: #2e3440ff;--s-min-dark-bg: #1f1f1f;--s-min-light-bg: #ffffff')
+
+    const snippet = `
+<style>
+.shiki {
+  padding: 0.5em;
+  border-radius: 0.25em;
+}
+
+[data-theme="dark"] .shiki {
+  background-color: var(--s-dark-bg) !important;
+  color: var(--s-dark) !important;
+}
+[data-theme="dark"] .shiki span {
+  color: var(--s-dark) !important;
+}
+
+[data-theme="nord"] .shiki {
+  background-color: var(--s-nord-bg) !important;
+  color: var(--s-nord) !important;
+}
+[data-theme="nord"] .shiki span {
+  color: var(--s-nord) !important;
+}
+
+[data-theme="min-dark"] .shiki {
+  background-color: var(--s-min-dark-bg) !important;
+  color: var(--s-min-dark) !important;
+}
+[data-theme="min-dark"] .shiki span {
+  color: var(--s-min-dark) !important;
+}
+
+[data-theme="min-light"] .shiki {
+  background-color: var(--s-min-light-bg) !important;
+  color: var(--s-min-light) !important;
+}
+[data-theme="min-light"] .shiki span {
+  color: var(--s-min-light) !important;
+}
+</style>
+<script>
+const themes = ['light', 'dark', 'nord', 'min-dark', 'min-light']
+
+function toggleTheme() {
+  document.body.dataset.theme = themes[(Math.max(themes.indexOf(document.body.dataset.theme), 0) + 1) % themes.length]
+}
+</script>
+<button onclick="toggleTheme()">Toggle theme</button>
+`
+    const code = renderToHtml(tokens, { rootStyle, themeName: rootClass })
+    expect(snippet + code)
+      .toMatchFileSnapshot('./out/multiple-themes-tokens.html')
+  })
+
+  it('multiple themes without default', async () => {
+    const { rootClass, rootStyle, tokens } = await codeToThemedTokensDualThemes('console.log("hello")', {
+      lang: 'js',
+      themes: {
+        'light': 'vitesse-light',
+        'dark': 'vitesse-dark',
+        'nord': 'nord',
+        'min-dark': 'min-dark',
+        'min-light': 'min-light',
+      },
+      cssVariablePrefix: '--s-',
+      defaultColor: false,
+    })
+
+    expect(rootClass).toEqual('shiki shiki-dual-themes vitesse-light vitesse-dark nord min-dark min-light')
+    expect(rootStyle).toEqual('--s-light: #393a34;--s-dark: #dbd7caee;--s-nord: #d8dee9ff;--s-min-dark: #b392f0;--s-min-light: #24292eff;--s-light-bg: #ffffff;--s-dark-bg: #121212;--s-nord-bg: #2e3440ff;--s-min-dark-bg: #1f1f1f;--s-min-light-bg: #ffffff')
+
+    const snippet = `
+<style>
+.shiki {
+  padding: 0.5em;
+  border-radius: 0.25em;
+}
+
+.shiki {
+  background-color: var(--s-light-bg);
+  color: var(--s-light);
+}
+.shiki span {
+  color: var(--s-light)
+}
+
+[data-theme="dark"] .shiki {
+  background-color: var(--s-dark-bg);
+  color: var(--s-dark);
+}
+[data-theme="dark"] .shiki span {
+  color: var(--s-dark);
+}
+
+[data-theme="nord"] .shiki {
+  background-color: var(--s-nord-bg);
+  color: var(--s-nord);
+}
+[data-theme="nord"] .shiki span {
+  color: var(--s-nord);
+}
+
+[data-theme="min-dark"] .shiki {
+  background-color: var(--s-min-dark-bg);
+  color: var(--s-min-dark);
+}
+[data-theme="min-dark"] .shiki span {
+  color: var(--s-min-dark);
+}
+
+[data-theme="min-light"] .shiki {
+  background-color: var(--s-min-light-bg);
+  color: var(--s-min-light);
+}
+[data-theme="min-light"] .shiki span {
+  color: var(--s-min-light);
+}
+</style>
+<script>
+const themes = ['light', 'dark', 'nord', 'min-dark', 'min-light']
+
+function toggleTheme() {
+  document.body.dataset.theme = themes[(Math.max(themes.indexOf(document.body.dataset.theme), 0) + 1) % themes.length]
+}
+</script>
+<button onclick="toggleTheme()">Toggle theme</button>
+`
+
+    const code = renderToHtml(tokens, { rootStyle, themeName: rootClass })
+
+    expect(snippet + code)
+      .toMatchFileSnapshot('./out/multiple-themes-tokens-no-default.html')
   })
 })

--- a/packages/shikiji/test/out/multiple-themes-tokens-no-default.html
+++ b/packages/shikiji/test/out/multiple-themes-tokens-no-default.html
@@ -1,0 +1,56 @@
+
+<style>
+.shiki {
+  padding: 0.5em;
+  border-radius: 0.25em;
+}
+
+.shiki {
+  background-color: var(--s-light-bg);
+  color: var(--s-light);
+}
+.shiki span {
+  color: var(--s-light)
+}
+
+[data-theme="dark"] .shiki {
+  background-color: var(--s-dark-bg);
+  color: var(--s-dark);
+}
+[data-theme="dark"] .shiki span {
+  color: var(--s-dark);
+}
+
+[data-theme="nord"] .shiki {
+  background-color: var(--s-nord-bg);
+  color: var(--s-nord);
+}
+[data-theme="nord"] .shiki span {
+  color: var(--s-nord);
+}
+
+[data-theme="min-dark"] .shiki {
+  background-color: var(--s-min-dark-bg);
+  color: var(--s-min-dark);
+}
+[data-theme="min-dark"] .shiki span {
+  color: var(--s-min-dark);
+}
+
+[data-theme="min-light"] .shiki {
+  background-color: var(--s-min-light-bg);
+  color: var(--s-min-light);
+}
+[data-theme="min-light"] .shiki span {
+  color: var(--s-min-light);
+}
+</style>
+<script>
+const themes = ['light', 'dark', 'nord', 'min-dark', 'min-light']
+
+function toggleTheme() {
+  document.body.dataset.theme = themes[(Math.max(themes.indexOf(document.body.dataset.theme), 0) + 1) % themes.length]
+}
+</script>
+<button onclick="toggleTheme()">Toggle theme</button>
+<pre class="shiki shiki shiki-dual-themes vitesse-light vitesse-dark nord min-dark min-light" style="--s-light: #393a34;--s-dark: #dbd7caee;--s-nord: #d8dee9ff;--s-min-dark: #b392f0;--s-min-light: #24292eff;--s-light-bg: #ffffff;--s-dark-bg: #121212;--s-nord-bg: #2e3440ff;--s-min-dark-bg: #1f1f1f;--s-min-light-bg: #ffffff" tabindex="0"><code><span class="line"><span style="--s-light:#B07D48;--s-dark:#BD976A;--s-nord:#D8DEE9;--s-min-dark:#79B8FF;--s-min-light:#1976D2">console</span><span style="--s-light:#999999;--s-dark:#666666;--s-nord:#ECEFF4;--s-min-dark:#B392F0;--s-min-light:#6F42C1">.</span><span style="--s-light:#59873A;--s-dark:#80A665;--s-nord:#88C0D0;--s-min-dark:#B392F0;--s-min-light:#6F42C1">log</span><span style="--s-light:#999999;--s-dark:#666666;--s-nord:#D8DEE9FF;--s-min-dark:#B392F0;--s-min-light:#24292EFF">(</span><span style="--s-light:#B5695999;--s-dark:#C98A7D99;--s-nord:#ECEFF4;--s-min-dark:#FFAB70;--s-min-light:#22863A">&quot;</span><span style="--s-light:#B56959;--s-dark:#C98A7D;--s-nord:#A3BE8C;--s-min-dark:#FFAB70;--s-min-light:#22863A">hello</span><span style="--s-light:#B5695999;--s-dark:#C98A7D99;--s-nord:#ECEFF4;--s-min-dark:#FFAB70;--s-min-light:#22863A">&quot;</span><span style="--s-light:#999999;--s-dark:#666666;--s-nord:#D8DEE9FF;--s-min-dark:#B392F0;--s-min-light:#24292EFF">)</span></span></code></pre>

--- a/packages/shikiji/test/out/multiple-themes-tokens.html
+++ b/packages/shikiji/test/out/multiple-themes-tokens.html
@@ -1,0 +1,48 @@
+
+<style>
+.shiki {
+  padding: 0.5em;
+  border-radius: 0.25em;
+}
+
+[data-theme="dark"] .shiki {
+  background-color: var(--s-dark-bg) !important;
+  color: var(--s-dark) !important;
+}
+[data-theme="dark"] .shiki span {
+  color: var(--s-dark) !important;
+}
+
+[data-theme="nord"] .shiki {
+  background-color: var(--s-nord-bg) !important;
+  color: var(--s-nord) !important;
+}
+[data-theme="nord"] .shiki span {
+  color: var(--s-nord) !important;
+}
+
+[data-theme="min-dark"] .shiki {
+  background-color: var(--s-min-dark-bg) !important;
+  color: var(--s-min-dark) !important;
+}
+[data-theme="min-dark"] .shiki span {
+  color: var(--s-min-dark) !important;
+}
+
+[data-theme="min-light"] .shiki {
+  background-color: var(--s-min-light-bg) !important;
+  color: var(--s-min-light) !important;
+}
+[data-theme="min-light"] .shiki span {
+  color: var(--s-min-light) !important;
+}
+</style>
+<script>
+const themes = ['light', 'dark', 'nord', 'min-dark', 'min-light']
+
+function toggleTheme() {
+  document.body.dataset.theme = themes[(Math.max(themes.indexOf(document.body.dataset.theme), 0) + 1) % themes.length]
+}
+</script>
+<button onclick="toggleTheme()">Toggle theme</button>
+<pre class="shiki shiki shiki-dual-themes vitesse-light vitesse-dark nord min-dark min-light" style="color: #393a34; --s-light: #393a34;--s-dark: #dbd7caee;--s-nord: #d8dee9ff;--s-min-dark: #b392f0;--s-min-light: #24292eff;background-color: #ffffff; --s-light-bg: #ffffff;--s-dark-bg: #121212;--s-nord-bg: #2e3440ff;--s-min-dark-bg: #1f1f1f;--s-min-light-bg: #ffffff" tabindex="0"><code><span class="line"><span style="color:#B07D48;--s-dark:#BD976A;--s-nord:#D8DEE9;--s-min-dark:#79B8FF;--s-min-light:#1976D2">console</span><span style="color:#999999;--s-dark:#666666;--s-nord:#ECEFF4;--s-min-dark:#B392F0;--s-min-light:#6F42C1">.</span><span style="color:#59873A;--s-dark:#80A665;--s-nord:#88C0D0;--s-min-dark:#B392F0;--s-min-light:#6F42C1">log</span><span style="color:#999999;--s-dark:#666666;--s-nord:#D8DEE9FF;--s-min-dark:#B392F0;--s-min-light:#24292EFF">(</span><span style="color:#B5695999;--s-dark:#C98A7D99;--s-nord:#ECEFF4;--s-min-dark:#FFAB70;--s-min-light:#22863A">&quot;</span><span style="color:#B56959;--s-dark:#C98A7D;--s-nord:#A3BE8C;--s-min-dark:#FFAB70;--s-min-light:#22863A">hello</span><span style="color:#B5695999;--s-dark:#C98A7D99;--s-nord:#ECEFF4;--s-min-dark:#FFAB70;--s-min-light:#22863A">&quot;</span><span style="color:#999999;--s-dark:#666666;--s-nord:#D8DEE9FF;--s-min-dark:#B392F0;--s-min-light:#24292EFF">)</span></span></code></pre>


### PR DESCRIPTION
Added to dual themes for themed tokens,  It helps with custom transformers, e.g. nodes converted to [hast](https://github.com/syntax-tree/hastscript).
