### PR TITLE
docs: upgrade CDN URLs to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ To use `shikiji` in the browser via CDN, you can use [esm.run](https://esm.run) 
 
   <script type="module">
     // be sure to specify the exact version
-    import { codeToHtml } from 'https://esm.sh/shikiji@0.4.0' 
+    import { codeToHtml } from 'https://esm.sh/shikiji@0.5.0' 
     // or
-    // import { codeToHtml } from 'https://esm.run/shikiji@0.4.0' 
+    // import { codeToHtml } from 'https://esm.run/shikiji@0.5.0' 
 
     const foo = document.getElementById('foo')
     foo.innerHTML = await codeToHtml('console.log("Hi, Shiki on CDN :)")', { lang: 'js', theme: 'vitesse-light' })


### PR DESCRIPTION
Update the outdated CDN urls.

<img width="1211" alt="Screenshot 2023-08-18 at 20 12 18" src="https://github.com/antfu/shikiji/assets/2883484/2adaf8c2-3bc4-4bfb-8121-9ebc2a08665b">


