### PR TITLE
feat(transforms): add line node element to `token` transformer

### DIFF
--- a/packages/shikiji/src/core/renderer-hast.ts
+++ b/packages/shikiji/src/core/renderer-hast.ts
@@ -153,7 +153,7 @@ export function tokensToHast(
         children: [{ type: 'text', value: token.content }],
       }
 
-      tokenNode = options.transforms?.token?.(tokenNode, idx + 1, col) || tokenNode
+      tokenNode = options.transforms?.token?.(tokenNode, idx + 1, col, lineNode) || tokenNode
 
       lineNode.children.push(tokenNode)
       col += token.content.length

--- a/packages/shikiji/src/types.ts
+++ b/packages/shikiji/src/types.ts
@@ -277,7 +277,7 @@ export interface HastTransformers {
    * @param line 1-based line number
    */
   line?: (hast: Element, line: number) => Element | void
-  token?: (hast: Element, line: number, col: number) => Element | void
+  token?: (hast: Element, line: number, col: number, lineElement: Element) => Element | void
 }
 
 export interface HtmlRendererOptions {

--- a/packages/shikiji/test/hast.test.ts
+++ b/packages/shikiji/test/hast.test.ts
@@ -39,3 +39,30 @@ describe('should', () => {
       .toMatchInlineSnapshot('"<pre class=\\"shiki vitesse-light\\" style=\\"background-color:#ffffff;color:#393a34\\" tabindex=\\"0\\"><code class=\\"language-js\\"><span class=\\"line\\" data-line=\\"1\\"><span style=\\"color:#B07D48\\" class=\\"token:1:0\\">foo</span><span style=\\"color:#393A34\\" class=\\"token:1:3\\"></span><span style=\\"color:#B07D48\\" class=\\"token:1:4\\">ar</span></span></code></pre>"')
   })
 })
+
+it('hasfocus support', async () => {
+  const snippet = '$foo = "bar";\n'
+    + '$test = "owo"; // [!code focus]\n'
+    + '$bar = "baz";'
+
+  const code = await codeToHtml(snippet, {
+    lang: 'php',
+    theme: 'vitesse-light',
+    transforms: {
+      code(node) {
+        node.properties.class = 'language-php'
+      },
+      token(node, line, col, parent) {
+        node.children.forEach((child) => {
+          if (child.type === 'text' && child.value.includes('[!code focus]')) {
+            parent.properties['data-has-focus'] = 'true'
+            node.children.splice(node.children.indexOf(child), 1)
+          }
+        })
+      },
+    },
+  })
+
+  expect(code)
+    .toMatchInlineSnapshot('"<pre class=\\"shiki vitesse-light\\" style=\\"background-color:#ffffff;color:#393a34\\" tabindex=\\"0\\"><code class=\\"language-php\\"><span class=\\"line\\"><span style=\\"color:#999999\\">$</span><span style=\\"color:#B07D48\\">foo</span><span style=\\"color:#999999\\"> =</span><span style=\\"color:#B5695999\\"> \\"</span><span style=\\"color:#B56959\\">bar</span><span style=\\"color:#B5695999\\">\\"</span><span style=\\"color:#999999\\">;</span></span>\n<span class=\\"line\\" data-has-focus=\\"true\\"><span style=\\"color:#999999\\">$</span><span style=\\"color:#B07D48\\">test</span><span style=\\"color:#999999\\"> =</span><span style=\\"color:#B5695999\\"> \\"</span><span style=\\"color:#B56959\\">owo</span><span style=\\"color:#B5695999\\">\\"</span><span style=\\"color:#999999\\">;</span><span style=\\"color:#A0ADA0\\"></span></span>\n<span class=\\"line\\"><span style=\\"color:#999999\\">$</span><span style=\\"color:#B07D48\\">bar</span><span style=\\"color:#999999\\"> =</span><span style=\\"color:#B5695999\\"> \\"</span><span style=\\"color:#B56959\\">baz</span><span style=\\"color:#B5695999\\">\\"</span><span style=\\"color:#999999\\">;</span></span></code></pre>"')
+})


### PR DESCRIPTION
This pull request adds the current line node to the `token` transformer. This is useful because it makes it easy to transform the whole line when a specific token meets some conditions.

My use-case, specifically, is to re-implement VitePress' ["focus" feature](https://vitepress.dev/guide/markdown#focus-in-code-blocks), which comes from [this underlying library](https://github.com/innocenzi/shiki-processor/blob/main/src/processors/focus.ts), which uses Shiki's `lineOptions`.
