### PR TITLE
fix: remove empty style

### DIFF
--- a/packages/shikiji/src/core/renderer-hast.ts
+++ b/packages/shikiji/src/core/renderer-hast.ts
@@ -157,16 +157,16 @@ export function tokensToHast(
     let col = 0
 
     for (const token of line) {
-      const styles = [token.htmlStyle || stringifyTokenStyle(getTokenStyles(token))]
-
       let tokenNode: Element = {
         type: 'element',
         tagName: 'span',
-        properties: {
-          style: styles.join(';'),
-        },
+        properties: {},
         children: [{ type: 'text', value: token.content }],
       }
+
+      const style = token.htmlStyle || stringifyTokenStyle(getTokenStyles(token))
+      if (style)
+        tokenNode.properties.style = style
 
       tokenNode = options.transforms?.token?.(tokenNode, idx + 1, col, lineNode) || tokenNode
 

--- a/packages/shikiji/test/themes.test.ts
+++ b/packages/shikiji/test/themes.test.ts
@@ -197,6 +197,18 @@ function toggleTheme() {
     expect(code2)
       .toContain('font-style:inherit;--shiki-light-font-style:italic')
   })
+
+  it('should not have empty style', async () => {
+    const input = 'This is plain text'
+    const code = await codeToHtml(input, {
+      lang: 'plaintext',
+      themes: {
+        light: 'material-theme-palenight',
+        dark: 'nord',
+      },
+    })
+    expect(code).not.toContain('style=""')
+  })
 })
 
 describe('codeToTokensWithThemes', () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
In plaintext syntax highlighting when `<span>`s has no `style`, shikiji was generating `style=""` the spans. This PR removes that empty style attribute.

### Linked Issues

n/a

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Found this while trying to integrate this in Astro: https://github.com/withastro/astro/pull/8502
