### PR TITLE
fix: add lang to HtmlRendererOptions

### DIFF
--- a/packages/shikiji/src/types.ts
+++ b/packages/shikiji/src/types.ts
@@ -281,6 +281,7 @@ export interface HastTransformers {
 }
 
 export interface HtmlRendererOptions {
+  lang?: string
   langId?: string
   fg?: string
   bg?: string


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The type check is breaking at master, and this PR solves it by adding the `lang` property to the `HtmlRendererOptions`.

### Linked PR

The lang property is new and comes from #26.
