### PR TITLE
feat(rehype-shikiji): add language class to code element

### DIFF
--- a/packages/rehype-shikiji/src/index.ts
+++ b/packages/rehype-shikiji/src/index.ts
@@ -22,6 +22,13 @@ export type RehypeShikijiOptions = CodeOptionsThemes<BuiltinTheme> & {
   highlightLines?: boolean | string
 
   /**
+   * Add `language-*` class to code element
+   *
+   * @default false
+   */
+  addLanguageClass?: boolean
+
+  /**
    * Extra meta data to pass to the highlighter
    */
   meta?: Record<string, any>
@@ -40,6 +47,7 @@ export type RehypeShikijiOptions = CodeOptionsThemes<BuiltinTheme> & {
 const rehypeShikiji: Plugin<[RehypeShikijiOptions], Root> = function (options = {} as any) {
   const {
     highlightLines = true,
+    addLanguageClass = false,
     parseMetaString,
     ...rest
   } = options
@@ -91,6 +99,17 @@ const rehypeShikiji: Plugin<[RehypeShikijiOptions], Root> = function (options = 
           ...rest.meta,
           ...meta,
         },
+      }
+
+      if (addLanguageClass) {
+        codeOptions.transformers ||= []
+        codeOptions.transformers.push({
+          name: 'rehype-shikiji:code-language-class',
+          code(node) {
+            addClassToHast(node, language)
+            return node
+          },
+        })
       }
 
       if (highlightLines && typeof attrs === 'string') {

--- a/packages/rehype-shikiji/test/fixtures/b.md
+++ b/packages/rehype-shikiji/test/fixtures/b.md
@@ -1,0 +1,8 @@
+# Hello
+
+…world!
+
+```js
+const b = 2
+console.log(b)
+```

--- a/packages/rehype-shikiji/test/fixtures/b.out.html
+++ b/packages/rehype-shikiji/test/fixtures/b.out.html
@@ -1,0 +1,5 @@
+<h1>Hello</h1>
+<p>…world!</p>
+<pre class="shiki vitesse-light" style="background-color:#ffffff;color:#393a34" tabindex="0"><code class="language-js"><span class="line"><span style="color:#AB5959">const</span><span style="color:#B07D48"> b</span><span style="color:#999999"> =</span><span style="color:#2F798A"> 2</span></span>
+<span class="line"><span style="color:#B07D48">console</span><span style="color:#999999">.</span><span style="color:#59873A">log</span><span style="color:#999999">(</span><span style="color:#B07D48">b</span><span style="color:#999999">)</span></span>
+<span class="line"></span></code></pre>

--- a/packages/rehype-shikiji/test/index.test.ts
+++ b/packages/rehype-shikiji/test/index.test.ts
@@ -27,3 +27,17 @@ it('run', async () => {
 
   expect(file.toString()).toMatchFileSnapshot('./fixtures/a.out.html')
 })
+
+it('code-add-language-class', async () => {
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkRehype)
+    .use(rehypeShikiji, {
+      theme: 'vitesse-light',
+      addLanguageClass: true,
+    })
+    .use(rehypeStringify)
+    .process(await fs.readFile(new URL('./fixtures/b.md', import.meta.url)))
+
+  expect(file.toString()).toMatchFileSnapshot('./fixtures/b.out.html')
+})


### PR DESCRIPTION
### Description

Added an option to add the `language-*` class to the code element which is needed in some scenario.
Not sure if it should be enabled or disabled by default, i set it to disabled for now.
Also added a unit test for it
