### PR TITLE
fix: load all embedded langs with markdown

### DIFF
--- a/packages/shikiji/scripts/prepare.ts
+++ b/packages/shikiji/scripts/prepare.ts
@@ -37,9 +37,9 @@ for (const file of allLangFiles) {
     unbalancedBracketSelectors: lang.unbalancedBracketSelectors,
   }
 
-  // Do not include everything for markdown
-  if (lang.id === 'markdown')
-    json.embeddedLangs = []
+  // F# and Markdown has circular dependency
+  if (lang.id === 'fsharp')
+    json.embeddedLangs = json.embeddedLangs.filter((i: string) => i !== 'markdown')
 
   const embedded = (json.embeddedLangs || []) as string[]
 

--- a/packages/shikiji/test/index.test.ts
+++ b/packages/shikiji/test/index.test.ts
@@ -85,6 +85,23 @@ describe('should', () => {
         ]
       `)
   })
+
+  // https://github.com/antfu/shikiji/issues/35
+  it('dynamic load theme and lang with md', async () => {
+    const shiki = await getHighlighter({})
+
+    await shiki.loadTheme('min-dark')
+    await shiki.loadLanguage('md')
+    await shiki.loadLanguage('js')
+
+    expect(shiki.getLoadedLanguages())
+      .toMatchInlineSnapshot()
+    expect(shiki.getLoadedThemes())
+      .toMatchInlineSnapshot()
+
+    expect(shiki.codeToHtml('console.log(1)', { lang: 'js', theme: 'min-dark' }))
+      .toMatchInlineSnapshot()
+  })
 })
 
 describe('errors', () => {

--- a/packages/shikiji/test/index.test.ts
+++ b/packages/shikiji/test/index.test.ts
@@ -55,33 +55,101 @@ describe('should', () => {
     expect(shiki.getLoadedLanguages().sort())
       .toMatchInlineSnapshot(`
         [
+          "bash",
+          "bat",
+          "batch",
+          "bibtex",
+          "c",
+          "c#",
+          "c++",
+          "clj",
+          "clojure",
+          "cmd",
           "coffee",
+          "cpp",
+          "cs",
+          "csharp",
           "css",
+          "dart",
+          "diff",
+          "docker",
+          "dockerfile",
+          "elixir",
+          "erl",
+          "erlang",
+          "f#",
+          "fs",
+          "fsharp",
+          "git-commit",
+          "git-rebase",
+          "glsl",
+          "gnuplot",
+          "go",
           "gql",
           "graphql",
+          "groovy",
+          "handlebars",
+          "haskell",
+          "hbs",
+          "hs",
           "html",
+          "ini",
           "jade",
+          "java",
           "javascript",
           "js",
           "json",
           "json5",
           "jsonc",
           "jsx",
+          "julia",
+          "latex",
           "less",
+          "lua",
+          "make",
+          "makefile",
           "markdown",
           "md",
+          "objc",
+          "objective-c",
+          "perl",
+          "perl6",
+          "php",
+          "powershell",
+          "properties",
+          "ps",
+          "ps1",
           "pug",
+          "py",
+          "python",
+          "r",
+          "raku",
+          "rb",
+          "rs",
+          "ruby",
+          "rust",
           "sass",
+          "scala",
           "scss",
+          "sh",
+          "shell",
+          "shellscript",
+          "sql",
           "styl",
           "stylus",
+          "swift",
+          "tex",
           "toml",
           "ts",
           "tsx",
           "typescript",
+          "vb",
           "vue",
+          "xml",
+          "xsl",
           "yaml",
           "yml",
+          "zsh",
         ]
       `)
   })
@@ -94,13 +162,25 @@ describe('should', () => {
     await shiki.loadLanguage('md')
     await shiki.loadLanguage('js')
 
-    expect(shiki.getLoadedLanguages())
-      .toMatchInlineSnapshot()
+    expect(shiki.getLoadedLanguages().length)
+      .toMatchInlineSnapshot(`89`)
+
     expect(shiki.getLoadedThemes())
-      .toMatchInlineSnapshot()
+      .toMatchInlineSnapshot(`
+        [
+          "min-dark",
+        ]
+      `)
 
     expect(shiki.codeToHtml('console.log(1)', { lang: 'js', theme: 'min-dark' }))
-      .toMatchInlineSnapshot()
+      .toMatchInlineSnapshot(`"<pre class="shiki min-dark" style="background-color:#1f1f1f;color:#b392f0" tabindex="0"><code><span class="line"><span style="color:#79B8FF">console</span><span style="color:#B392F0">.log(</span><span style="color:#F8F8F8">1</span><span style="color:#B392F0">)</span></span></code></pre>"`)
+
+    expect(shiki.codeToHtml('```js\nconsole.log(1)\n```', { lang: 'md', theme: 'min-dark' }))
+      .toMatchInlineSnapshot(`
+        "<pre class="shiki min-dark" style="background-color:#1f1f1f;color:#b392f0" tabindex="0"><code><span class="line"><span style="color:#9DB1C5">\`\`\`js</span></span>
+        <span class="line"><span style="color:#79B8FF">console</span><span style="color:#B392F0">.log(</span><span style="color:#F8F8F8">1</span><span style="color:#B392F0">)</span></span>
+        <span class="line"><span style="color:#9DB1C5">\`\`\`</span></span></code></pre>"
+      `)
   })
 })
 


### PR DESCRIPTION
fix #35

After this change, load `markdown` will load 86 of other languages. Which is not very optimal, but I still need to research if it's possible to load and use embedded language on-demand or afterwards.