### PR TITLE
perf: skip `setTheme` if theme hasn't changed

### DIFF
--- a/packages/shikiji-core/src/internal.ts
+++ b/packages/shikiji-core/src/internal.ts
@@ -47,6 +47,8 @@ export async function getShikiInternal(options: HighlighterCoreOptions = {}): Pr
   Object.assign(_registry.alias, options.langAlias)
   await _registry.init()
 
+  let _lastTheme: ThemeRegistrationResolved
+
   function getLangGrammar(name: string) {
     const _lang = _registry.getGrammar(name)
     if (!_lang)
@@ -63,7 +65,10 @@ export async function getShikiInternal(options: HighlighterCoreOptions = {}): Pr
 
   function setTheme(name: string | ThemeRegistrationResolved) {
     const theme = getTheme(name)
-    _registry.setTheme(theme)
+    if (_lastTheme !== theme) {
+      _registry.setTheme(theme)
+      _lastTheme = theme
+    }
     const colorMap = _registry.getColorMap()
     return {
       theme,

--- a/packages/shikiji-core/src/internal.ts
+++ b/packages/shikiji-core/src/internal.ts
@@ -47,7 +47,7 @@ export async function getShikiInternal(options: HighlighterCoreOptions = {}): Pr
   Object.assign(_registry.alias, options.langAlias)
   await _registry.init()
 
-  let _lastTheme: ThemeRegistrationResolved
+  let _lastTheme: string | ThemeRegistrationResolved
 
   function getLangGrammar(name: string) {
     const _lang = _registry.getGrammar(name)
@@ -65,9 +65,9 @@ export async function getShikiInternal(options: HighlighterCoreOptions = {}): Pr
 
   function setTheme(name: string | ThemeRegistrationResolved) {
     const theme = getTheme(name)
-    if (_lastTheme !== theme) {
+    if (_lastTheme !== name) {
       _registry.setTheme(theme)
-      _lastTheme = theme
+      _lastTheme = name
     }
     const colorMap = _registry.getColorMap()
     return {


### PR DESCRIPTION
### Description

Porting over https://github.com/shikijs/shiki/pull/151, which improves performance of `codeToThemedTokens` when invoked multiple times with the same theme. Please see that PR for details.

### Additional context

I'm trying to switch https://github.com/banga/git-split-diffs over to `shikiji`, but this is a blocker since it makes rendering significantly slower the way I use it.