### PR TITLE
Adds 'hcLight' & 'hcDark' to Theme type

### DIFF
--- a/packages/shikiji-core/src/types.ts
+++ b/packages/shikiji-core/src/types.ts
@@ -380,7 +380,7 @@ export interface ThemeRegistrationResolved extends RawTheme {
    *
    * @field shikiji custom property
    */
-  type: 'light' | 'dark'
+  type: 'light' | 'dark' | 'hcLight' | 'hcDark'
 
   /**
    * Token rules


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Adds `'hcLight'` & `'hcDark'` to the `type` allowed values in the `ThemeRegistrationResolved` interface. 

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
