### PR TITLE
fix(vitepress-plugin-twoslash): fix floating jump

### DIFF
--- a/packages/vitepress-plugin-twoslash/src/renderer-floating-vue.ts
+++ b/packages/vitepress-plugin-twoslash/src/renderer-floating-vue.ts
@@ -90,6 +90,7 @@ export function rendererFloatingVue(options: VitePressPluginTwoSlashOptions & Re
         'placement': 'bottom-start',
         'theme': 'twoslash',
         ':arrow-padding': '8',
+        ':auto-boundary-max-size': 'true',
         ...presisted && {
           ':shown': 'true',
           ':triggers': '[]',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Currently, type hover triggers unexpectedly scroll jump, caused by the floating popper doesn't have enough size to display properly. `[floating-vue](https://floating-vue.starpad.dev/api/#autoboundarymaxsize)` has `autoBoundaryMaxSize` prop to limit the max height, it should fix this bug(Video below ⬇️).

https://github.com/antfu/shikiji/assets/35442047/ee90cf21-d0b9-431d-8fa2-94870acddf6d



### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
