### PR TITLE
docs: fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 An ESM-focused rewrite of [shiki](https://github.com/shikijs/shiki), a beautiful syntax highlighter based on TextMate grammars, with more features and capabilities.
 
-[📚 **Documentations**](https://shikiji.netlify.app)
+[📚 **Documentation**](https://shikiji.netlify.app)
 
 ## License
 


### PR DESCRIPTION
Should be "documentation" instead of plural "documentations" I think.