### PR TITLE
fix(rehype-shikiji): lazily initialize promise

### DIFF
--- a/packages/rehype-shikiji/src/index.ts
+++ b/packages/rehype-shikiji/src/index.ts
@@ -24,14 +24,17 @@ const rehypeShikiji: Plugin<[RehypeShikijiOptions], Root> = function (
 
   // eslint-disable-next-line ts/no-this-alias
   const ctx = this
-  const promise = getHighlighter({
-    themes: themeNames,
-    langs,
-  })
-    .then(highlighter => rehypeShikijiFromHighlighter.call(ctx, highlighter, options))
+  let promise: Promise<any>
 
   return async function (tree) {
-    const handler = await promise as any
+    if (!promise) {
+      promise = getHighlighter({
+        themes: themeNames,
+        langs,
+      })
+        .then(highlighter => rehypeShikijiFromHighlighter.call(ctx, highlighter, options))
+    }
+    const handler = await promise
     return handler!(tree) as Root
   }
 }


### PR DESCRIPTION
### Description

Seemed to be running into aggressive memory consumption with a large number of inputs into `rehypeShikiji`. Lazily initializing the promise seemed to fix it. Can spin up a minimal repro if you need!